### PR TITLE
tweaked a few things

### DIFF
--- a/LaserScarecrow/CommandProcessor.cpp
+++ b/LaserScarecrow/CommandProcessor.cpp
@@ -32,7 +32,8 @@ void CommandProcessor::setSettings(Settings *stgs)
 void CommandProcessor::setStream(Stream *st)
 {
   stream = st;
-  stream->println(F("Laser Scarecrow Command Processor Ready!"));
+  //stream->println(F("Laser Scarecrow Command Processor Ready!"));
+  //this was silly; we don't know there's anyone listening yet.
 }
 
 void CommandProcessor::process()
@@ -48,6 +49,8 @@ void CommandProcessor::process()
         stream->print(' ');
         switch (command->code) {
           case CPCODE_Hello:
+            stream->print(SOFTWARE_VERSION);
+            stream->print(' ');
             processOK();
             break;
           case CPCODE_StateCurrent:

--- a/LaserScarecrow/IrReflectanceSensor.cpp
+++ b/LaserScarecrow/IrReflectanceSensor.cpp
@@ -34,6 +34,9 @@ bool IrReflectanceSensor::isPresent() {
 #endif
 
 }
+bool IrReflectanceSensor::isDisabled() {
+  return _disabled;
+}
 
 int IrReflectanceSensor::read()
 {

--- a/LaserScarecrow/IrReflectanceSensor.h
+++ b/LaserScarecrow/IrReflectanceSensor.h
@@ -33,6 +33,7 @@ class IrReflectanceSensor
     static void setPresentThreshold(int value);
     static void setDisabled(bool disabled);
     static bool isPresent();
+    static bool isDisabled();
     static int read();
 };
 #endif // not defined

--- a/LaserScarecrow/LaserScarecrow.ino
+++ b/LaserScarecrow/LaserScarecrow.ino
@@ -482,7 +482,12 @@ void loop() { // put your main code here, to run repeatedly:
 #ifdef DEBUG_REFLECTANCE
     Serial.print(F("\r\nIR raw="));
     Serial.print(IrReflectanceSensor::read());
-    Serial.print(IrReflectanceSensor::isPresent() ? F(" Present;") : F(" not present;"));
+    if(IrReflectanceSensor::isDisabled) {
+      Serial.println(F(" (disabled)"));
+    } else
+    {
+      Serial.println(IrReflectanceSensor::isPresent() ? F(" (tape present)") : F(" (no tape)"));
+    }
 #endif
 #ifdef DEBUG_AMBIENT
     Serial.print(F("Ambient light average="));
@@ -514,15 +519,16 @@ void loop() { // put your main code here, to run repeatedly:
 #ifdef DEBUG_RTC
     rtc.refresh();
 
-    Serial.print(F("\r\nRTC DateTime: "));
-    Serial.print(rtc.year());
-    Serial.print('/');
-    Serial.print(rtc.month());
-    Serial.print('/');
-    Serial.print(rtc.day());
+//    Serial.print(F("\r\nRTC DateTime: "));
+//    Serial.print(rtc.year());
+//    Serial.print('/');
+//    Serial.print(rtc.month());
+//    Serial.print('/');
+//    Serial.print(rtc.day());
 
-    Serial.print(' ');
-
+//    Serial.print(' ');
+// really we care only about the time:
+    Serial.print(F("\r\nRTC time: "));
     Serial.print(rtc.hour());
     Serial.print(':');
     Serial.print(rtc.minute());

--- a/LaserScarecrow/SettingsObserver.cpp
+++ b/LaserScarecrow/SettingsObserver.cpp
@@ -199,6 +199,7 @@ bool SettingsObserver::load(Settings *settings_ptr)
 #endif
 #endif
       *settings_ptr = tmpSettings; // shallow copy
+      _settings = tmpSettings; // so we don't try to save what was just loaded! 
     }
   } // if successfully loaded the header
   return success;

--- a/LaserScarecrow/config.h
+++ b/LaserScarecrow/config.h
@@ -8,11 +8,15 @@
 
 #pragma once
 
-#define SOFTWARE_VERSION F("Version 1.4_0 - dev - feat/16_bt_manual")
+#define SOFTWARE_VERSION F("Version 2.0_rc2 - Version 2 Release Candidate 2 - rc/v2_rc2")
 
 /*******************
    VERSION HISTORY
  *******************
+
+  2.0_rc2 - June 20, 2018 - release candidate 2
+
+  2.0_rc1 - release candidate 1 - still had a bug in inverted tape sensor
 
   1.4_1 - June 2018 - branch feat/1_invert_tape_sensor (via #define in config.ini)
   
@@ -160,8 +164,9 @@
 // these thresholds will be raw values when using AnalogInput
 #define INTERRUPT_FREQUENCY_KNOB_CHANGE_THRESHOLD 20
 #define SERVO_PULSE_KNOB_CHANGE_THRESHOLD 20
-//for testing, save settings 30000 ms (30 seconds) after last change; change to 300000 (5 minutes) for release
-#define SETTINGSOBSERVER_SAVE_AFTER_MS 30000
+//for testing, save settings 30000 ms (30 seconds) after last change; change to 100000 (100 seconds; we're telling them 2 minutes) for release
+#define SETTINGSOBSERVER_SAVE_AFTER_MS 100000
+//laser will stay on this long after movement in manual mode
 #define STATE_MANUAL_LASER_OFF_DELAY_MS 15000
 
 /*************
@@ -234,21 +239,21 @@
  */
 #define DEBUG_SERIAL
 #define DEBUG_SERIAL_DATARATE 57600
-#define DEBUG_SERIAL_OUTPUT_INTERVAL_MS 4000
+#define DEBUG_SERIAL_OUTPUT_INTERVAL_MS 10000
 #define DEBUG_SERIAL_COUNTDOWN_SECONDS 4
 //#define DEBUG_SERVO
 //#define DEBUG_KNOBS
 //#define DEBUG_LIGHTSENSOR
 #define DEBUG_REFLECTANCE
 //#define DEBUG_REFLECTANCE_INIT_READINGS
-//#define DEBUG_SETTINGS
+#define DEBUG_SETTINGS
 //#define DEBUG_SETTINGS_VERBOSE
-//#define DEBUG_SETTINGSOBSERVER
+#define DEBUG_SETTINGSOBSERVER
 
 //#define DEBUG_STEPPER
 //#define DEBUG_STEPPER_STEPS
 //#define DEBUG_LASERCONTROLLER
 //#define DEBUG_LASER_DUTY_CYCLE
 //#define DEBUG_INTERRUPT_FREQUENCY
-//#define DEBUG_RTC
+#define DEBUG_RTC
 //#define DEBUG_BLUETOOTH


### PR DESCRIPTION
Removed message sent to serial with no listener; added software version to L0 response. Set config.h #defines suitably for production vs. development. (Serial debug is still enabled) Added IrReflectanceSensor::isDisabled() to allow more informative serial debug. Removed display of RTC year/month/day in serial debug. When SettingsObserver::load() is successful, it will also change its cached _settings so it doesn't think the loaded settings need to be saved.