### PR TITLE
RTC removed

### DIFF
--- a/LaserScarecrow/CommandProcessor.h
+++ b/LaserScarecrow/CommandProcessor.h
@@ -12,7 +12,7 @@
    responsibilities.
 
    Created by David H. Brown, February 25, 2018
-   License TBD
+   License TBD, but includes GPL components, so there's that...
    Part of the URI Laser Scarecrow project
 */
 #ifndef CommandProcessor_h
@@ -24,11 +24,7 @@
 #include "IrReflectanceSensor.h"
 #include "StepperController.h"
 #include "ServoController.h"
-#include <uRTCLib.h>
-// make a RTC class of my own?
-extern uRTCLib rtc;
-extern bool rtc_is_running;
-// same for the state?
+
 extern byte stateCurrent, statePrevious;
 extern bool stateManual;
 
@@ -52,11 +48,6 @@ extern bool stateManual;
 #define CPCODE_RtcControl 201
 #define CPCODE_LightSensorRead 210
 #define CPCODE_LightThrehold 221
-#define CPCODE_RtcYmd 251
-#define CPCODE_RtcHms 252
-#define CPCODE_RtcRunning 259
-#define CPCODE_RtcWake 261
-#define CPCODE_RtcSleep 262
 
 
 enum CPSTATUS {

--- a/LaserScarecrow/config.h
+++ b/LaserScarecrow/config.h
@@ -13,6 +13,8 @@
    VERSION HISTORY
  *******************
 
+  2.3.1 - remove RTC support. Never going to be used vs. ambient light; don't need the battery-backed RAM, either (using EEPROM)
+
   2.3.0 - better support for Bluetooth control and tape sensor. 
   
   2.1.1 beta - issue #32 attempt to find minimum useful span and set random steps accordingly
@@ -250,10 +252,8 @@
 #define LED1_INVERT true
 #define LED2_PIN LED_BUILTIN_TX
 #define LED2_INVERT true
-
-#define RTC_WIRE_RTC_ADDRESS 0x68
-#define RTC_WIRE_EE_ADDRESS 0x57
-/***************************
+ 
+ /***************************
  * DEBUG Flags
  */
 #define DEBUG_SERIAL
@@ -274,5 +274,4 @@
 //#define DEBUG_LASERCONTROLLER
 //#define DEBUG_LASER_DUTY_CYCLE
 //#define DEBUG_INTERRUPT_FREQUENCY
-//#define DEBUG_RTC
 //#define DEBUG_BLUETOOTH


### PR DESCRIPTION
Per discussion with Dr. Rebecca Brown, it is unlikely the real-time clock (RTC) will ever be used to control the active period. Its initial inclusion was as much for the 56 bytes of battery-backed RAM which could have been used to store settings, but EEPROM is currently used for that purpose.